### PR TITLE
Limit speed to a minimum of 0.2

### DIFF
--- a/module.js
+++ b/module.js
@@ -198,6 +198,10 @@ export class ModuleSpec {
                 speed = speed.add(beacon)
             }
         }
+        let minimum = Rational.from_floats(1, 5)
+        if (speed.less(minimum)) {
+            speed = minimum
+        }
         return speed
     }
     prodEffect(spec) {


### PR DESCRIPTION
This only really occurs with cryogenics plants with 8 productivity modules, but it turns out it's also a minimum of 20% just like power consumption.

Fixes #259