### PR TITLE
Separate settings for Space Age advanced machines

### DIFF
--- a/building.js
+++ b/building.js
@@ -33,10 +33,10 @@ class Building {
         this.icon = new Icon(this)
     }
     less(other) {
-        if (!this.speed.equal(other.speed)) {
-            return this.speed.less(other.speed)
+        if (this.moduleSlots != other.moduleSlots) {
+            return this.moduleSlots < other.moduleSlots
         }
-        return this.moduleSlots < other.moduleSlots
+        return this.speed.less(other.speed)
     }
     getCount(spec, recipe, rate) {
         return rate.div(this.getRecipeRate(spec, recipe))

--- a/calc.css
+++ b/calc.css
@@ -172,7 +172,7 @@ input.prec, input.mprod {
 .radio-setting input[type="radio"] {
     display: none;
 }
-.radio-setting input[type="radio"] + label {
+.radio-setting input[type="radio"] + label, .toggle-building {
     cursor: pointer;
     background: var(--light);
     border-radius: 4px;
@@ -180,10 +180,10 @@ input.prec, input.mprod {
     margin: 2px;
     padding: 2px;
 }
-.radio-setting input[type="radio"] + label:hover {
+.radio-setting input[type="radio"] + label:hover, .toggle-building:hover {
     background: var(--bright);
 }
-.radio-setting input[type="radio"]:checked + label {
+.radio-setting input[type="radio"]:checked + label, .toggle-building.selected {
     background: var(--accent);
 }
 .toggle-list .toggle {

--- a/calc.html
+++ b/calc.html
@@ -231,6 +231,11 @@ limitations under the License.-->
             <td><span id="building_selector"></span></td>
             </tr>
 
+            <tr id="advanced_building_row" class="setting-row">
+            <td class="setting-label"><div><span>Advanced buildings:</span></div></td>
+            <td><div id="advanced_building_selector"></div></td>
+            </tr>
+
             <tr class="setting-row">
             <td class="setting-label">Mining productivity bonus:</td>
             <td>+<input id="mprod" class="mprod" type="number" step="10" value="0" min="0" onchange="handlers.changeMprod(event)">%</td>

--- a/factory.js
+++ b/factory.js
@@ -36,29 +36,6 @@ let DEFAULT_BUILDINGS = new Set([
     "electric-mining-drill",
 ])
 
-class BuildingSet {
-    constructor(building) {
-        this.categories = new Set(building.categories)
-        this.buildings = new Set([building])
-    }
-    merge(other) {
-        for (let category of other.categories) {
-            this.categories.add(category)
-        }
-        for (let building of other.buildings) {
-            this.buildings.add(building)
-        }
-    }
-    overlap(other) {
-        for (let category of this.categories) {
-            if (other.categories.has(category)) {
-                return true
-            }
-        }
-        return false
-    }
-}
-
 export function buildingSort(buildings) {
     buildings.sort(function(a, b) {
         if (a.less(b)) {
@@ -99,23 +76,18 @@ class BuildingGroup {
 }
 
 function getBuildingGroups(buildings) {
-    let sets = new Set()
+    let sets = new Map()
     for (let building of buildings) {
-        let set = new BuildingSet(building)
-        for (let s of Array.from(sets)) {
-            if (set.overlap(s)) {
-                set.merge(s)
-                sets.delete(s)
+        for (let cat of building.categories) {
+            if (!sets.has(cat)) {
+                sets.set(cat, new Set())
             }
+            sets.get(cat).add(building)
         }
-        sets.add(set)
     }
     let groups = new Map()
-    for (let {categories, buildings} of sets) {
-        let group = new BuildingGroup(buildings)
-        for (let cat of categories) {
-            groups.set(cat, group)
-        }
+    for (let [cat, buildingSet] of sets.entries()) {
+        groups.set(cat, new BuildingGroup(buildingSet))
     }
     return groups
 }
@@ -129,6 +101,7 @@ class FactorySpecification {
         this.planets = null
         this.buildings = null
         this.buildingKeys = null
+        this.advancedBuildings = new Set()
         this.belts = null
         this.fuels = null
 
@@ -496,15 +469,35 @@ class FactorySpecification {
         let cat = Array.from(building.categories)[0]
         return this.buildings.get(cat)
     }
-    setMinimumBuilding(building) {
-        let group = this.getBuildingGroup(building)
-        group.building = building
+    setMinimumBuilding(building, setBefore = false) {
+        for (let cat of building.categories) {
+            let group = this.buildings.get(cat)
+            let groupIndex = group.buildings.indexOf(building)
+            if (setBefore && groupIndex > 0) {
+                // This probably won't work well if there start to be more than two tiers in a category,
+                // but... in that case probably the whole BuildingGroup abstraction needs a rework.
+                group.building = group.buildings[groupIndex - 1]
+            } else {
+                group.building = building
+            }
+        }
         for (let [recipe, moduleSpec] of this.spec) {
-            let g = this.buildings.get(recipe.category)
-            if (group === g) {
+            if (building.categories.has(recipe.category)) {
                 let b = this.getBuilding(recipe)
                 moduleSpec.setBuilding(b, this)
             }
+        }
+    }
+    hasAdvancedBuildingEnabled(building) {
+        return this.advancedBuildings.has(building)
+    }
+    setAdvancedBuildingEnabled(building, enabled) {
+        if (enabled) {
+            this.advancedBuildings.add(building)
+            this.setMinimumBuilding(building, false)
+        } else {
+            this.advancedBuildings.delete(building)
+            this.setMinimumBuilding(building, true)
         }
     }
     initModuleSpec(recipe, building) {

--- a/fragment.js
+++ b/fragment.js
@@ -71,6 +71,12 @@ export function formatSettings(excludeTitle, overrideTab, targets) {
     if (buildings.length > 0) {
         settings += "buildings=" + buildings.join(",") + "&"
     }
+    if (spec.advancedBuildings.size > 0) {
+        let advancedKeys = Array.from(spec.advancedBuildings)
+            .map(b => b.key)
+            .join(",")
+        settings += "advancedbuildings=" + advancedKeys + "&"
+    }
     if (spec.belt.key !== DEFAULT_BELT) {
         settings += "belt=" + spec.belt.key + "&"
     }
@@ -144,7 +150,7 @@ export function formatSettings(excludeTitle, overrideTab, targets) {
         }
         settings += "&planet=" + planets.join(",")
     }
-    let {disable, enable} = spec.getNetDisable()
+    let { disable, enable } = spec.getNetDisable()
     if (disable.size !== 0) {
         let parts = []
         for (let d of disable) {
@@ -198,7 +204,7 @@ export function formatSettings(excludeTitle, overrideTab, targets) {
         let priority = []
         for (let level of spec.priority) {
             let keys = []
-            for (let {recipe, weight} of level) {
+            for (let { recipe, weight } of level) {
                 keys.push(`${recipe.key}=${weight.toString()}`)
             }
             priority.push(keys.join(","))
@@ -233,7 +239,7 @@ export function loadSettings(fragment) {
     if (settings.has("zip")) {
         let z = window.atob(settings.get("zip"))
         let a = z.split("").map(c => c.charCodeAt(0))
-        let unzip = pako.inflateRaw(a, {to: "string"})
+        let unzip = pako.inflateRaw(a, { to: "string" })
         return loadSettings("#" + unzip)
     }
     return settings

--- a/settings.js
+++ b/settings.js
@@ -67,7 +67,7 @@ function normalizeDataSetName(modName) {
 // initialization, and so does not need to wipe and re-render its UI elements.
 export function renderDataSetOptions(settings) {
     let modSelector = document.getElementById("data_set")
-    d3.select(modSelector).on("change", function(event) {
+    d3.select(modSelector).on("change", function (event) {
         changeMod()
     })
     let configuredMod = normalizeDataSetName(settings.get("data"))
@@ -281,7 +281,7 @@ function renderRateOptions(settings) {
     spec.format.setDisplayRate(rateName)
     let rates = []
     for (let [rateName, longRateName] of longRateNames) {
-        rates.push({rateName, longRateName})
+        rates.push({ rateName, longRateName })
     }
     let form = d3.select("#display_rate")
     form.selectAll("*").remove()
@@ -356,16 +356,16 @@ function renderColorScheme(settings) {
     }
     setColorScheme(color)
     d3.select("#color_scheme")
-        .on("change", function(event, d) {
+        .on("change", function (event, d) {
             setColorScheme(event.target.value)
             spec.display()
         })
         .selectAll("option")
         .data(colorSchemes)
         .join("option")
-            .attr("value", d => d.key)
-            .property("selected", d => d.key === color)
-            .text(d => d.name)
+        .attr("value", d => d.key)
+        .property("selected", d => d.key === color)
+        .text(d => d.name)
 }
 
 function setColorScheme(schemeKey) {
@@ -381,15 +381,13 @@ function setColorScheme(schemeKey) {
 // buildings
 
 function renderBuildings(settings) {
-    let groupSet = new Set()
-    for (let [cat, group] of spec.buildings) {
-        if (group.buildings.length > 1) {
-            groupSet.add(group)
-        }
-    }
-    for (let group of groupSet) {
-        group.building = group.getDefault()
-    }
+    const singleSelectCategories = [
+        "crafting",
+        "smelting",
+        "basic-solid",
+    ]
+    let groups = singleSelectCategories.map(cat => spec.buildings.get(cat))
+    groups.forEach(group => group.building = group.getDefault())
     if (settings.has("buildings")) {
         let buildingKeys = settings.get("buildings").split(",")
         for (let key of buildingKeys) {
@@ -402,9 +400,6 @@ function renderBuildings(settings) {
         }
     }
 
-    // It doesn't really matter how we order these, but pick something just to
-    // make it consistent.
-    let groups = sorted(groupSet, g => g.getDefault().name)
     let groupIndex = new Map()
     for (let [i, g] of groups.entries()) {
         for (let building of g.buildings) {
@@ -416,7 +411,7 @@ function renderBuildings(settings) {
     let set = div.selectAll("div")
         .data(groups)
         .join("div")
-            .classed("radio-setting", true)
+        .classed("radio-setting", true)
     radioSetting(
         set,
         d => `building_selector_${groupIndex.get(d)}`,
@@ -427,6 +422,53 @@ function renderBuildings(settings) {
             spec.updateSolution()
         },
     )
+}
+
+function renderAdvancedBuildings(settings) {
+    // In Space Age, these buildings have significant caveats and unlock conditions.
+    // So we separate them out into their own group to allow multiple-selection of
+    // the buildings the user wants to allow building with.
+    const multiSelectCategories = [
+        "metallurgy",
+        "electromagnetics",
+        "organic",
+        "cryogenics",
+    ]
+    let buildings = multiSelectCategories
+        .map(cat => spec.buildings.get(cat))
+        .filter(categoryBuildings => categoryBuildings != undefined)
+        .flatMap(categoryBuildings => categoryBuildings.buildings)
+    buildingSort(buildings)
+
+    if (settings.has("advancedbuildings")) {
+        let buildingKeys = settings.get("advancedbuildings").split(",")
+        for (let key of buildingKeys) {
+            let building = spec.buildingKeys.get(key)
+            if (building === undefined) {
+                console.log("unknown building:", key)
+                continue
+            }
+            spec.setAdvancedBuildingEnabled(building, true)
+        }
+    }
+
+    d3.select("#advanced_building_row")
+        .style("display", buildings.length == 0 ? "none" : null)
+
+    let div = d3.select("#advanced_building_selector")
+    div.selectAll("*").remove()
+    let building = div.selectAll("div")
+        .data(buildings)
+        .join("div")
+        .classed("toggle-building", true)
+        .classed("selected", d => spec.hasAdvancedBuildingEnabled(d))
+        .on("click", function (event, d) {
+            let enabled = spec.hasAdvancedBuildingEnabled(d)
+            d3.select(this).classed("selected", !enabled)
+            spec.setAdvancedBuildingEnabled(d, !enabled)
+            spec.updateSolution()
+        })
+    building.append(d => d.icon.make(32))
 }
 
 // belt
@@ -751,28 +793,28 @@ function renderRecipes(settings) {
         planetDiv.selectAll("div")
             .data(planets)
             .join("div")
-                .classed("toggle", true)
-                .classed("selected", d => spec.selectedPlanets.has(d))
-                .on("click", function(event, d) {
-                    if (event.shiftKey) {
-                        event.preventDefault()
-                        let selected = spec.selectedPlanets.has(d)
-                        d3.select(this).classed("selected", !selected)
-                        if (selected) {
-                            spec.unselectPlanet(d)
-                        } else {
-                            spec.selectPlanet(d)
-                        }
+            .classed("toggle", true)
+            .classed("selected", d => spec.selectedPlanets.has(d))
+            .on("click", function (event, d) {
+                if (event.shiftKey) {
+                    event.preventDefault()
+                    let selected = spec.selectedPlanets.has(d)
+                    d3.select(this).classed("selected", !selected)
+                    if (selected) {
+                        spec.unselectPlanet(d)
                     } else {
-                        spec.selectOnePlanet(d)
-                        d3.selectAll("#planet_selector .toggle")
-                            .classed("selected", d => spec.selectedPlanets.has(d))
+                        spec.selectPlanet(d)
                     }
-                    d3.selectAll("#recipe_toggles .toggle")
-                        .classed("selected", d => !spec.disable.has(d))
-                    spec.updateSolution()
-                })
-                .append(d => d.icon.make(32))
+                } else {
+                    spec.selectOnePlanet(d)
+                    d3.selectAll("#planet_selector .toggle")
+                        .classed("selected", d => spec.selectedPlanets.has(d))
+                }
+                d3.selectAll("#recipe_toggles .toggle")
+                    .classed("selected", d => !spec.disable.has(d))
+                spec.updateSolution()
+            })
+            .append(d => d.icon.make(32))
     }
 
     let allGroups = getRecipeGroups(new Set(spec.recipes.values()))
@@ -789,22 +831,22 @@ function renderRecipes(settings) {
     let recipe = div.selectAll("div")
         .data(groups)
         .join("div")
-            .classed("toggle-row", true)
-            .selectAll("div")
-            .data(d => d)
-            .join("div")
-                .classed("toggle recipe", true)
-                .classed("selected", d => !spec.disable.has(d))
-                .on("click", function(event, d) {
-                    let disabled = spec.disable.has(d)
-                    d3.select(this).classed("selected", disabled)
-                    if (disabled) {
-                        spec.setEnable(d)
-                    } else {
-                        spec.setDisable(d)
-                    }
-                    spec.updateSolution()
-                })
+        .classed("toggle-row", true)
+        .selectAll("div")
+        .data(d => d)
+        .join("div")
+        .classed("toggle recipe", true)
+        .classed("selected", d => !spec.disable.has(d))
+        .on("click", function (event, d) {
+            let disabled = spec.disable.has(d)
+            d3.select(this).classed("selected", disabled)
+            if (disabled) {
+                spec.setEnable(d)
+            } else {
+                spec.setDisable(d)
+            }
+            spec.updateSolution()
+        })
     recipe.append(d => d.icon.make(32))
 }
 
@@ -856,6 +898,7 @@ export function renderSettings(settings) {
     renderMiningProd(settings)
     renderColorScheme(settings)
     renderBuildings(settings)
+    renderAdvancedBuildings(settings)
     renderBelts(settings)
     renderFuel(settings)
     renderVisualizer(settings)


### PR DESCRIPTION
Before, they were mixed into a false upgrade chain of the assemblers. Now, they have a separate section where each one can be individually toggled, allowing users to customize the calculator to what buildings they've unlocked so far.

The most notable change here is that when selecting the assembler 3 before, it would also enable many other advanced machines (such as the cryogenics plant), which made it hard to plan correctly around those machines prior to visiting Aquilo.