### PR TITLE
Fix Space Age machines not actually being disabled at first

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -440,6 +440,8 @@ function renderAdvancedBuildings(settings) {
         .flatMap(categoryBuildings => categoryBuildings.buildings)
     buildingSort(buildings)
 
+    buildings.forEach(b => spec.setAdvancedBuildingEnabled(b, false))
+
     if (settings.has("advancedbuildings")) {
         let buildingKeys = settings.get("advancedbuildings").split(",")
         for (let key of buildingKeys) {


### PR DESCRIPTION
They appeared to be in the settings, but were actually favored in recipes.